### PR TITLE
Truncate long domain and scenario names

### DIFF
--- a/src/features/activity/data/executions-columns.tsx
+++ b/src/features/activity/data/executions-columns.tsx
@@ -51,7 +51,7 @@ export const executionsColumns: ColumnDef<Execution>[] = [
               }}
             />
           )}
-          <span className='truncate text-sm'>{identity.name}</span>
+          <span className='truncate text-sm' title={identity.name}>{identity.name}</span>
         </>
       )
 
@@ -62,7 +62,8 @@ export const executionsColumns: ColumnDef<Execution>[] = [
               href={formatUrl(identity.url)}
               target='_blank'
               rel='noopener noreferrer'
-              className='flex items-center gap-2 hover:underline'
+              className='flex min-w-0 items-center gap-2 hover:underline'
+              title={identity.name}
             >
               {content}
             </a>
@@ -90,7 +91,7 @@ export const executionsColumns: ColumnDef<Execution>[] = [
 
       return (
         <div className='w-[160px]'>
-          <span className='truncate'>{playbookName || playbookId}</span>
+          <span className='block truncate' title={playbookName || playbookId}>{playbookName || playbookId}</span>
         </div>
       )
     },
@@ -115,9 +116,10 @@ export const executionsColumns: ColumnDef<Execution>[] = [
         <div className='w-[160px]'>
           <span
             className={cn(
-              'text-wrap break-words',
+              'block truncate',
               scenarioName ? '' : 'text-muted-foreground italic'
             )}
+            title={scenarioName || 'Deleted Scenario'}
           >
             {scenarioName || 'Deleted Scenario'}
           </span>


### PR DESCRIPTION
## Description

This PR addresses the display of long domain names, playbook names, and scenario names in the executions table. It implements truncation with ellipsis for these fields to ensure consistent readability and maintain table layout stability. Additionally, hover tooltips (`title` attributes) have been added to display the full text of truncated names.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Further comments

The changes specifically include:
- Adding `title` attributes to the relevant `span` and `a` elements to provide full text on hover.
- Introducing `min-w-0` to link containers for domain names to ensure proper truncation within flex layouts.
- Changing the display of scenario names from `text-wrap break-words` to `block truncate` for consistent ellipsis truncation.
- Applying `block truncate` to playbook names for similar consistent behavior.

## Related Issue

Closes: #<!-- Issue number, if applicable -->

---
[Slack Thread](https://swan-ai.slack.com/archives/D092C3Q46J3/p1757928896106809?thread_ts=1757928896.106809&cid=D092C3Q46J3)

<a href="https://cursor.com/background-agent?bcId=bc-e53dcb54-4472-48d0-b8ac-995ec41b958b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e53dcb54-4472-48d0-b8ac-995ec41b958b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

